### PR TITLE
Added LZMA support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/proio-org/go-proio
 require (
 	github.com/golang/protobuf v1.2.0
 	github.com/pierrec/lz4 v2.0.3+incompatible
+	github.com/smira/lzma v0.0.0-20160124201817-7f0af6269940
 	golang.org/x/net v0.0.0-20180821023952-922f4815f713 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/pierrec/lz4 v2.0.3+incompatible
 	github.com/smira/lzma v0.0.0-20160124201817-7f0af6269940
+	go-hep.org/x/hep v0.14.0
 	golang.org/x/net v0.0.0-20180821023952-922f4815f713 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 )

--- a/non-example_benchmark_test.go
+++ b/non-example_benchmark_test.go
@@ -75,6 +75,14 @@ func BenchmarkWriteGZIP(b *testing.B) {
 	doWrite(writer, b)
 }
 
+func BenchmarkWriteLZMA(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(LZMA)
+
+	doWrite(writer, b)
+}
+
 func BenchmarkReadUncomp(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
@@ -99,6 +107,16 @@ func BenchmarkReadGZIP(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(GZIP)
+	doWrite(writer, b)
+
+	reader := NewReader(buffer)
+	doRead(reader, b)
+}
+
+func BenchmarkReadLZMA(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(LZMA)
 	doWrite(writer, b)
 
 	reader := NewReader(buffer)

--- a/non-example_write_read_test.go
+++ b/non-example_write_read_test.go
@@ -173,6 +173,26 @@ func TestGZIPPushSkipGet2(t *testing.T) {
 	eventPushSkipGet2(GZIP, t)
 }
 
+func TestLZMAPushGet1(t *testing.T) {
+	eventPushGet1(LZMA, t)
+}
+
+func TestLZMAPushGet2(t *testing.T) {
+	eventPushGet2(LZMA, t)
+}
+
+func TestLZMAPushGet3(t *testing.T) {
+	eventPushGet3(LZMA, t)
+}
+
+func TestLZMAPushSkipGet1(t *testing.T) {
+	eventPushSkipGet1(LZMA, t)
+}
+
+func TestLZMAPushSkipGet2(t *testing.T) {
+	eventPushSkipGet2(LZMA, t)
+}
+
 func eventPushGet1(comp Compression, t *testing.T) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
@@ -433,6 +453,10 @@ func TestWriteLZ4IterateFile(t *testing.T) {
 
 func TestWriteGZIPIterateFile(t *testing.T) {
 	writeIterateFile(GZIP, t)
+}
+
+func TestWriteLZMAIterateFile(t *testing.T) {
+	writeIterateFile(LZMA, t)
 }
 
 func TestWriteUncompIterateFile(t *testing.T) {

--- a/reader.go
+++ b/reader.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pierrec/lz4"
 	proto "github.com/proio-org/go-proio-pb"
+	"github.com/smira/lzma"
 )
 
 // Reader serves to read Events from a stream in the proio format.  The Reader
@@ -311,6 +312,9 @@ func (rdr *Reader) readBucket(maxSkipEvents int) (eventsSkipped int, err error) 
 			lz4Rdr = lz4.NewReader(rdr.bucket)
 		}
 		rdr.bucketReader = lz4Rdr
+	case proto.BucketHeader_LZMA:
+        lzmaRdr := lzma.NewReader(rdr.bucket)
+		rdr.bucketReader = lzmaRdr
 	default:
 		rdr.bucketReader = rdr.bucket
 	}

--- a/tools/lcio2proio/main.go
+++ b/tools/lcio2proio/main.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	outFile        = flag.String("o", "", "create file to save output to")
-	compLevel      = flag.Int("c", 2, "compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
+	compLevel      = flag.Int("c", 2, "compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression, 3 for LZMA compression")
 	updateInterval = flag.Int("u", 5, "update interval in seconds (set to 0 to disable)")
 )
 
@@ -60,6 +60,8 @@ func main() {
 		}
 	}
 	switch *compLevel {
+	case 3:
+		proioWriter.SetCompression(proio.LZMA)
 	case 2:
 		proioWriter.SetCompression(proio.GZIP)
 	case 1:

--- a/tools/proio-strip/main.go
+++ b/tools/proio-strip/main.go
@@ -16,7 +16,7 @@ var (
 	intersection  = flag.Bool("i", false, "only strip the intersection of the specified tags (entries that each have all tags)")
 	keep          = flag.Bool("k", false, "keep only entries with the specified tags, rather than stripping them away")
 	stripMetadata = flag.Bool("m", false, "strip all metadata")
-	compLevel     = flag.Int("c", 2, "output compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
+	compLevel     = flag.Int("c", 2, "output compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression, 3 for LZMA compression")
 )
 
 func printUsage() {
@@ -69,6 +69,8 @@ func main() {
 		}
 	}
 	switch *compLevel {
+	case 3:
+		writer.SetCompression(proio.LZMA)
 	case 2:
 		writer.SetCompression(proio.GZIP)
 	case 1:

--- a/tools/proio-summary/main.go
+++ b/tools/proio-summary/main.go
@@ -62,6 +62,7 @@ func main() {
 		log.Print(err)
 	}
 
+	fmt.Println("Number of LZMA buckets:", nBuckets[proto.BucketHeader_LZMA])
 	fmt.Println("Number of LZ4 buckets:", nBuckets[proto.BucketHeader_LZ4])
 	fmt.Println("Number of GZIP buckets:", nBuckets[proto.BucketHeader_GZIP])
 	fmt.Println("Number of uncompressed buckets:", nBuckets[proto.BucketHeader_NONE])


### PR DESCRIPTION
Added LZMA support due to discussion with Jakob Blomer (@jblomer) and Sergei Chekanov (@chekanov).  This is an exploratory step using go-proio as a test bed.

```shell
go test -run=^$ -bench=. -count=2
```
yields
```
goos: linux
goarch: amd64
pkg: github.com/proio-org/go-proio
BenchmarkWriteUncomp-4              	   10000	    143196 ns/op
BenchmarkWriteUncomp-4              	   10000	    127207 ns/op
BenchmarkWriteLZ4-4                 	   10000	    181942 ns/op
BenchmarkWriteLZ4-4                 	   10000	    182045 ns/op
BenchmarkWriteGZIP-4                	    5000	   1387495 ns/op
BenchmarkWriteGZIP-4                	    5000	   1410371 ns/op
BenchmarkWriteLZMA-4                	    5000	   7600407 ns/op
BenchmarkWriteLZMA-4                	    5000	   8160611 ns/op
BenchmarkReadUncomp-4               	    5000	    273842 ns/op
BenchmarkReadUncomp-4               	    5000	    265726 ns/op
BenchmarkReadLZ4-4                  	    5000	    280866 ns/op
BenchmarkReadLZ4-4                  	    5000	    278016 ns/op
BenchmarkReadGZIP-4                 	    5000	    429477 ns/op
BenchmarkReadGZIP-4                 	    5000	    428137 ns/op
BenchmarkReadLZMA-4                 	    5000	    337367 ns/op
BenchmarkReadLZMA-4                 	    5000	    343990 ns/op
BenchmarkAddRemove100Entries-4      	   20000	     62899 ns/op
BenchmarkAddRemove100Entries-4      	   30000	     70580 ns/op
BenchmarkAddRemove1000Entries-4     	    2000	    667663 ns/op
BenchmarkAddRemove1000Entries-4     	    2000	    572896 ns/op
BenchmarkAddRemove10000Entries-4    	     300	   5172163 ns/op
BenchmarkAddRemove10000Entries-4    	     300	   5160005 ns/op
BenchmarkAddRemove100000Entries-4   	      20	  76742944 ns/op
BenchmarkAddRemove100000Entries-4   	      20	  74920485 ns/op
PASS
ok  	github.com/proio-org/go-proio	226.741s
```
on my core-i5 system.  This serves to give a basic relative idea of write/read performance with LZMA in proio.  Write speed is far worse than even GZIP, but of course we should expect it to be worse.  Read speed is interestingly better than for GZIP.

As for size-on-disk, I took this file: http://mc.hep.anl.gov/asc/hepsim/events/pp/13tev/pythia8_qcd_proio//tev13_pythia8_qcdjets_pt50_001.proio and reencoded it using the `proio-strip` tool (can be obtained from [here](https://github.com/proio-org/go-proio/releases/tag/v0.1.1_lzma_test)) into each available compression type with the command
```shell
time proio-strip -c $COMP_LEVEL tev13_pythia8_qcdjets_pt50_001.proio > $COMP_LEVEL.proio
```
where COMP_LEVEL is one of 0,1,2,3 corresponding to different compression types (see command-line help).  To get meaningful encoding times for the process, I first reencoded the file to be uncompressed, and then performed the encoding from there.  The resulting file sizes are as follows:
* Uncompressed: 198 MB (0.3s encoding time)
* LZ4: 122 MB (1.9s encoding time)
* GZIP: 107 MB (6.3s encoding time)
* LZMA: 91 MB (2m6s encoding time)

Obviously the compression time for LZMA is bananas (at least for the [go LZMA implementation used](http://github.com/smira/lzma)), but there is a decent improvement of file size, and there is no apparent decompression penalty.