### PR TITLE
[WIP] Reader.Skip() and everything related changing under the hood

### DIFF
--- a/non-example_benchmark_test.go
+++ b/non-example_benchmark_test.go
@@ -9,14 +9,14 @@ import (
 	prolcio "github.com/proio-org/go-proio-pb/model/lcio"
 )
 
-func doWrite(writer *Writer, b *testing.B) {
-	if b.N < 5000 {
-		b.N = 5000
+func doWrite(writer *Writer, b *testing.B, n int) {
+	if b.N < 1000 {
+		b.N = 1000
 	}
 
 	event := NewEvent()
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < n-1; i++ {
 		event.AddEntry("SimCaloHits", &prolcio.SimCalorimeterHit{
 			Energy: rand.Float32(),
 			Pos: []float32{
@@ -51,73 +51,91 @@ func doRead(reader *Reader, b *testing.B) {
 	}
 }
 
-func BenchmarkWriteUncomp(b *testing.B) {
+func BenchmarkWrite1000EntriesUncomp(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(UNCOMPRESSED)
 
-	doWrite(writer, b)
+	doWrite(writer, b, 1000)
 }
 
-func BenchmarkWriteLZ4(b *testing.B) {
-	buffer := &bytes.Buffer{}
-	writer := NewWriter(buffer)
-	writer.SetCompression(LZ4)
-
-	doWrite(writer, b)
-}
-
-func BenchmarkWriteGZIP(b *testing.B) {
-	buffer := &bytes.Buffer{}
-	writer := NewWriter(buffer)
-	writer.SetCompression(GZIP)
-
-	doWrite(writer, b)
-}
-
-func BenchmarkWriteLZMA(b *testing.B) {
-	buffer := &bytes.Buffer{}
-	writer := NewWriter(buffer)
-	writer.SetCompression(LZMA)
-
-	doWrite(writer, b)
-}
-
-func BenchmarkReadUncomp(b *testing.B) {
+func BenchmarkWrite10000EntriesUncomp(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(UNCOMPRESSED)
-	doWrite(writer, b)
 
-	reader := NewReader(buffer)
-	doRead(reader, b)
+	doWrite(writer, b, 10000)
 }
 
-func BenchmarkReadLZ4(b *testing.B) {
+func BenchmarkWrite1000EntriesLZ4(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(LZ4)
-	doWrite(writer, b)
 
-	reader := NewReader(buffer)
-	doRead(reader, b)
+	doWrite(writer, b, 1000)
 }
 
-func BenchmarkReadGZIP(b *testing.B) {
+func BenchmarkWrite1000EntriesGZIP(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(GZIP)
-	doWrite(writer, b)
+
+	doWrite(writer, b, 1000)
+}
+
+func BenchmarkWrite1000EntriesLZMA(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(LZMA)
+
+	doWrite(writer, b, 1000)
+}
+
+func BenchmarkReadWith1000EntriesUncomp(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(UNCOMPRESSED)
+	doWrite(writer, b, 1000)
 
 	reader := NewReader(buffer)
 	doRead(reader, b)
 }
 
-func BenchmarkReadLZMA(b *testing.B) {
+func BenchmarkReadWith10000EntriesUncomp(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(UNCOMPRESSED)
+	doWrite(writer, b, 10000)
+
+	reader := NewReader(buffer)
+	doRead(reader, b)
+}
+
+func BenchmarkReadWith1000EntriesLZ4(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(LZ4)
+	doWrite(writer, b, 1000)
+
+	reader := NewReader(buffer)
+	doRead(reader, b)
+}
+
+func BenchmarkReadWith1000EntriesGZIP(b *testing.B) {
+	buffer := &bytes.Buffer{}
+	writer := NewWriter(buffer)
+	writer.SetCompression(GZIP)
+	doWrite(writer, b, 1000)
+
+	reader := NewReader(buffer)
+	doRead(reader, b)
+}
+
+func BenchmarkReadWith1000EntriesLZMA(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(LZMA)
-	doWrite(writer, b)
+	doWrite(writer, b, 1000)
 
 	reader := NewReader(buffer)
 	doRead(reader, b)

--- a/non-example_write_read_test.go
+++ b/non-example_write_read_test.go
@@ -464,7 +464,7 @@ func TestWriteUncompIterateFile(t *testing.T) {
 }
 
 func writeIterateFile(comp Compression, t *testing.T) {
-	nEvents := 5
+	nEvents := 10
 
 	tmpDir, err := ioutil.TempDir("", "proiotest")
 	if err != nil {
@@ -480,24 +480,34 @@ func writeIterateFile(comp Compression, t *testing.T) {
 	}
 	writer.SetCompression(comp)
 	event := NewEvent()
-	for i := 0; i < nEvents; i++ {
+	writer.Push(event)
+	writer.Push(event)
+	writer.Flush()
+	writer.Push(event)
+	writer.Push(event)
+	writer.Flush()
+	for i := 0; i < nEvents-4; i++ {
 		writer.Push(event)
 	}
 	writer.Close()
-
-	nEvents = 0
 
 	reader, err := Open(tmpFile)
 	if err != nil {
 		t.Error(err)
 	}
+
+	eventCount := 0
+	reader.Skip(1)
+	reader.Next()
+	reader.Skip(2)
+	eventCount += 4
 	for range reader.ScanEvents() {
-		nEvents++
+		eventCount++
 	}
 	reader.Close()
 
-	if nEvents != 5 {
-		t.Errorf("nEvents is %v instead of 5", nEvents)
+	if eventCount != nEvents {
+		t.Errorf("eventCount is %v instead of %v", eventCount, nEvents)
 	}
 }
 

--- a/tools/proio-ls/main.go
+++ b/tools/proio-ls/main.go
@@ -67,7 +67,7 @@ func main() {
 	if *event >= 0 {
 		singleEvent = true
 		startingEvent = *event
-		if _, err = reader.Skip(*event); err != nil {
+		if _, err = reader.Skip(uint64(*event)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/tools/proio-summary/main.go
+++ b/tools/proio-summary/main.go
@@ -49,8 +49,10 @@ func main() {
 	nEvents := 0
 	nFDs := 0
 
-	var header *proto.BucketHeader
-	for header, err = reader.NextHeader(); header != nil; header, err = reader.NextHeader() {
+	reader.Skip(0)
+	for reader.BucketHeader != nil {
+		header := reader.BucketHeader
+
 		if err != nil {
 			log.Print(err)
 		}
@@ -58,6 +60,8 @@ func main() {
 		nBuckets[header.Compression]++
 		nEvents += int(header.NEvents)
 		nFDs += len(header.FileDescriptor)
+
+		reader.Skip(header.NEvents)
 	}
 
 	if err != nil && err != io.EOF {


### PR DESCRIPTION
These changes make the behavior very similar to cpp-proio.  The changes offer some minor performance improvement in some scenarios with lots of skipping, and I believe the operation is now easier to understand.