### PR TITLE
comp level and change to Reader error handling

### DIFF
--- a/event.go
+++ b/event.go
@@ -351,10 +351,13 @@ func addFDFromBytes(fdBytes []byte) (err error) {
 	fdProto := &descriptor.FileDescriptorProto{}
 
 	if err = protobuf.Unmarshal(fdBytes, fdProto); err == nil {
-		fdProtoStore.Store(fdProto.GetName(), fdProto)
+		_, ok := fdProtoStore.Load(fdProto.GetName())
+		if !ok {
+			fdProtoStore.Store(fdProto.GetName(), fdProto)
 
-		for _, descProto := range fdProto.GetMessageType() {
-			fdProtoForTypeStore.Store(fdProto.GetPackage()+"."+descProto.GetName(), fdProto)
+			for _, descProto := range fdProto.GetMessageType() {
+				fdProtoForTypeStore.Store(fdProto.GetPackage()+"."+descProto.GetName(), fdProto)
+			}
 		}
 	}
 

--- a/example_push_get_inspect_test.go
+++ b/example_push_get_inspect_test.go
@@ -38,7 +38,7 @@ func Example_pushGetInspect() {
 	// Event created and serialized, now to deserialize and inspect
 
 	reader := proio.NewReader(buffer)
-	eventIn, _ := reader.Next()
+	eventIn := reader.Next()
 
 	mcParts := eventIn.TaggedEntries("Primary")
 	fmt.Print(len(mcParts), " Primary particle(s)...\n")

--- a/example_scan_test.go
+++ b/example_scan_test.go
@@ -24,7 +24,7 @@ func Example_scan() {
 
 	reader := proio.NewReader(buffer)
 
-	for event := range reader.ScanEvents() {
+	for event := range reader.ScanEvents(10) {
 		fmt.Print(event)
 	}
 

--- a/example_skip_test.go
+++ b/example_skip_test.go
@@ -26,10 +26,10 @@ func Example_skip() {
 	reader := proio.NewReader(bytesReader)
 
 	reader.Skip(7)
-	event, _ := reader.Next()
+	event := reader.Next()
 	fmt.Print(event)
 	reader.SeekToStart()
-	event, _ = reader.Next()
+	event = reader.Next()
 	fmt.Print(event)
 
 	// Output:

--- a/non-example_benchmark_test.go
+++ b/non-example_benchmark_test.go
@@ -45,7 +45,7 @@ func doWrite(writer *Writer, b *testing.B, n int) {
 
 func doRead(reader *Reader, b *testing.B) {
 	b.ResetTimer()
-	for event := range reader.ScanEvents() {
+	for event := range reader.ScanEvents(100) {
 		trackHitID := event.TaggedEntries("SimTrackHits")[0]
 		_ = event.GetEntry(trackHitID)
 	}

--- a/non-example_file_descriptor_test.go
+++ b/non-example_file_descriptor_test.go
@@ -14,6 +14,7 @@ func TestWriteFD1(t *testing.T) {
 	writer := NewWriter(buffer)
 	event := NewEvent()
 	event.AddEntry("test", &eic.Particle{})
+	event.AddEntry("test", &eic.Particle{})
 	event.AddEntry("test", &mc.Particle{})
 	writer.Push(event)
 	if len(writer.writtenFDs) != 2 {
@@ -26,6 +27,7 @@ func TestWriteFD1(t *testing.T) {
 	reader.Close()
 
 	writer = NewWriter(buffer)
+	event.AddEntry("test", &eic.Particle{})
 	event.AddEntry("test", &eic.Particle{})
 	event.AddEntry("test", &mc.Particle{})
 	writer.Push(event)

--- a/non-example_file_descriptor_test.go
+++ b/non-example_file_descriptor_test.go
@@ -22,7 +22,7 @@ func TestWriteFD1(t *testing.T) {
 	writer.Close()
 
 	reader := NewReader(buffer)
-	event, _ = reader.Next()
+	event = reader.Next()
 	reader.Close()
 
 	writer = NewWriter(buffer)

--- a/non-example_metadata_test.go
+++ b/non-example_metadata_test.go
@@ -21,9 +21,9 @@ func TestPushUpdate1(t *testing.T) {
 	writer.Close()
 
 	reader := NewReader(buffer)
-	event1, _ := reader.Next()
-	event2, _ := reader.Next()
-	event3, _ := reader.Next()
+	event1 := reader.Next()
+	event2 := reader.Next()
+	event3 := reader.Next()
 	if string(event1.Metadata["key1"]) != "value1" {
 		t.Errorf("%v -> %v instead of %v", "key1", event1.Metadata["key1"], "value1")
 	}
@@ -48,9 +48,9 @@ func TestPushUpdate1(t *testing.T) {
 	writer.Close()
 
 	reader = NewReader(buffer)
-	event1, _ = reader.Next()
-	event2, _ = reader.Next()
-	event3, _ = reader.Next()
+	event1 = reader.Next()
+	event2 = reader.Next()
+	event3 = reader.Next()
 	if string(event1.Metadata["key1"]) != "value1" {
 		t.Errorf("%v -> %v instead of %v", "key1", event1.Metadata["key1"], "value1")
 	}

--- a/non-example_metadata_test.go
+++ b/non-example_metadata_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestPushUpdate1(t *testing.T) {
+func TestMetaPushUpdate1(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
 	writer := NewWriter(buffer)

--- a/non-example_write_read_test.go
+++ b/non-example_write_read_test.go
@@ -208,6 +208,7 @@ func eventPushGet1(comp Compression, t *testing.T) {
 	buffer := &bytes.Buffer{}
 	writer := NewWriter(buffer)
 	writer.SetCompression(comp)
+	writer.CompLevel = 1
 
 	var eventsOut [2]*Event
 

--- a/tools/proio-summary/main.go
+++ b/tools/proio-summary/main.go
@@ -80,8 +80,8 @@ func main() {
 	fmt.Println("Number of events:", nEvents)
 	fmt.Println("Number of FileDescriptorProtos:", nFDs)
 
-	fmt.Println()
 	if *printFileDescriptors {
+		fmt.Println()
 		protos := proio.StoredFileDescriptorProtos()
 		for _, proto := range protos {
 			fmt.Println(protobuf.MarshalTextString(proto))

--- a/writer.go
+++ b/writer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"reflect"
 	"sync"
 
 	protobuf "github.com/golang/protobuf/proto"
@@ -125,7 +124,7 @@ type getDependencyer interface {
 // memory are not reflected in the output stream.
 func (wrt *Writer) Push(event *Event) error {
 	for key, value := range event.Metadata {
-		if !reflect.DeepEqual(wrt.metadata[key], value) {
+		if !bytes.Equal(wrt.metadata[key], value) {
 			wrt.PushMetadata(key, value)
 			wrt.metadata[key] = value
 		}


### PR DESCRIPTION
This PR adds the CompLevel (Compression Level) member to Writer, and changes the way errors are handling when grabbing new events with Reader.

As for the compression level, this addition is not yet reflected in the tools.

The Reader no long returns an error along with an Event pointer on Next().  Now, only an Event pointer is returned, and the Reader.Err member is set.  For ScanEvents(), the function now takes an argument for how large of a read buffer to create.  Also, abnormal resynchronization of the stream is now reported, and causes Next() to return nil until called again.  This causes ScanEvents() to close the channel and allow the user to check Reader.Err.