### PR TITLE
writer.go: writeBytes(): now returns on any error regardless of the r…

### DIFF
--- a/tools/proio-strip/main.go
+++ b/tools/proio-strip/main.go
@@ -127,7 +127,7 @@ func main() {
 				}
 			}
 
-			if err := writer.Push(event); err != nil {
+			if err := writer.Push(event); err != nil && err != io.EOF {
 				log.Fatal(err)
 			}
 

--- a/writer.go
+++ b/writer.go
@@ -291,7 +291,7 @@ func writeBytes(wrt io.Writer, buf []byte) error {
 	for tot < len(buf) {
 		n, err := wrt.Write(buf[tot:])
 		tot += n
-		if err != nil && tot != len(buf) {
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
…eported bytes written