### PR TITLE
event.go: new AddSerializedEntry() receiver

### DIFF
--- a/non-example_event_test.go
+++ b/non-example_event_test.go
@@ -332,3 +332,34 @@ func TestCopyEvent(t *testing.T) {
 		t.Errorf("New event metadata are not independent")
 	}
 }
+
+func TestAddSerializedEntry(t *testing.T) {
+	desc, _ := (&example.Particle{}).Descriptor()
+
+	event := NewEvent()
+	id, err := event.AddSerializedEntry(
+		"Test",
+		[]byte{},
+		"proio.model.example.Particle",
+		desc,
+	)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if event.GetEntry(id) == nil {
+		t.Errorf("Entry failed to deserialize")
+	}
+
+	id, err = event.AddSerializedEntry(
+		"Test",
+		[]byte{},
+		"proio.model.example.NotReal",
+		[]byte("garbage"),
+	)
+	if err == nil {
+		t.Errorf("bad descriptor data not caught")
+	}
+	if event.GetEntry(id) != nil {
+		t.Errorf("fake message type somehow deserialized?")
+	}
+}


### PR DESCRIPTION
This is useful in cases where serialization of particular message types may be accelerated by some other encoder (hint: like FPGA).